### PR TITLE
Abstract exchanging keying material

### DIFF
--- a/keying.go
+++ b/keying.go
@@ -1,0 +1,45 @@
+package srtp
+
+const labelExtractorDtlsSrtp = "EXTRACTOR-dtls_srtp"
+
+// KeyingMaterialExporter allows package SRTP to extract keying material
+type KeyingMaterialExporter interface {
+	ExportKeyingMaterial(label string, context []byte, length int) ([]byte, error)
+}
+
+// ExtractSessionKeysFromDTLS allows setting the Config SessionKeys by
+// extracting them from DTLS. This behavior is defined in RFC5764:
+// https://tools.ietf.org/html/rfc5764
+func (c *Config) ExtractSessionKeysFromDTLS(exporter KeyingMaterialExporter, isClient bool) error {
+	keyingMaterial, err := exporter.ExportKeyingMaterial(labelExtractorDtlsSrtp, nil, (keyLen*2)+(saltLen*2))
+	if err != nil {
+		return err
+	}
+
+	offset := 0
+	clientWriteKey := append([]byte{}, keyingMaterial[offset:offset+keyLen]...)
+	offset += keyLen
+
+	serverWriteKey := append([]byte{}, keyingMaterial[offset:offset+keyLen]...)
+	offset += keyLen
+
+	clientWriteKey = append(clientWriteKey, keyingMaterial[offset:offset+saltLen]...)
+	offset += saltLen
+
+	serverWriteKey = append(serverWriteKey, keyingMaterial[offset:offset+saltLen]...)
+
+	if isClient {
+		c.Keys.LocalMasterKey = clientWriteKey[0:keyLen]
+		c.Keys.LocalMasterSalt = clientWriteKey[keyLen:]
+		c.Keys.RemoteMasterKey = serverWriteKey[0:keyLen]
+		c.Keys.RemoteMasterSalt = serverWriteKey[keyLen:]
+		return nil
+	}
+
+	c.Keys.LocalMasterKey = serverWriteKey[0:keyLen]
+	c.Keys.LocalMasterSalt = serverWriteKey[keyLen:]
+	c.Keys.RemoteMasterKey = clientWriteKey[0:keyLen]
+	c.Keys.RemoteMasterSalt = clientWriteKey[keyLen:]
+	return nil
+
+}

--- a/keying_test.go
+++ b/keying_test.go
@@ -1,0 +1,70 @@
+package srtp
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+type mockKeyingMaterialExporter struct {
+	exported []byte
+}
+
+func (m *mockKeyingMaterialExporter) ExportKeyingMaterial(label string, context []byte, length int) ([]byte, error) {
+	if label != labelExtractorDtlsSrtp {
+		return nil, fmt.Errorf("exporter called with wrong label: %s", label)
+	}
+
+	m.exported = make([]byte, length)
+	if _, err := rand.Read(m.exported); err != nil {
+		return nil, fmt.Errorf("failed to create random bytes: %v", err)
+	}
+
+	return m.exported, nil
+}
+
+func TestExtractSessionKeysFromDTLS(t *testing.T) {
+	tt := []struct {
+		config *Config
+	}{
+		{&Config{Profile: ProtectionProfileAes128CmHmacSha1_80}},
+	}
+
+	m := &mockKeyingMaterialExporter{}
+
+	for i, tc := range tt {
+		// Test client
+		err := tc.config.ExtractSessionKeysFromDTLS(m, true)
+		if err != nil {
+			t.Errorf("failed to extract keys for %d-client: %v", i, err)
+		}
+
+		keys := tc.config.Keys
+		clientMaterial := append([]byte{}, keys.LocalMasterKey...)
+		clientMaterial = append(clientMaterial, keys.RemoteMasterKey...)
+		clientMaterial = append(clientMaterial, keys.LocalMasterSalt...)
+		clientMaterial = append(clientMaterial, keys.RemoteMasterSalt...)
+
+		if !bytes.Equal(clientMaterial, m.exported) {
+			t.Errorf("material reconstruction failed for %d-client:\n%#v\nexpected\n%#v", i, clientMaterial, m.exported)
+		}
+
+		// Test server
+		err = tc.config.ExtractSessionKeysFromDTLS(m, false)
+		if err != nil {
+			t.Errorf("failed to extract keys for %d-server: %v", i, err)
+		}
+
+		keys = tc.config.Keys
+		serverMaterial := append([]byte{}, keys.RemoteMasterKey...)
+		serverMaterial = append(serverMaterial, keys.LocalMasterKey...)
+		serverMaterial = append(serverMaterial, keys.RemoteMasterSalt...)
+		serverMaterial = append(serverMaterial, keys.LocalMasterSalt...)
+
+		if !bytes.Equal(serverMaterial, m.exported) {
+			t.Errorf("material reconstruction failed for %d-server:\n%#v\nexpected\n%#v", i, serverMaterial, m.exported)
+		}
+
+	}
+}

--- a/session.go
+++ b/session.go
@@ -28,6 +28,23 @@ type session struct {
 	nextConn net.Conn
 }
 
+// Config is used to configure a session.
+// You can provide either a KeyingMaterialExporter to export keys
+// or directly pass the keys themselves.
+// After a Config is passed to a session it must not be modified.
+type Config struct {
+	Keys    SessionKeys
+	Profile ProtectionProfile
+}
+
+// SessionKeys bundles the keys required to setup an SRTP session
+type SessionKeys struct {
+	LocalMasterKey   []byte
+	LocalMasterSalt  []byte
+	RemoteMasterKey  []byte
+	RemoteMasterSalt []byte
+}
+
 func (s *session) getOrCreateReadStream(ssrc uint32, child streamSession, proto readStream) (readStream, bool) {
 	s.readStreamsLock.Lock()
 	defer s.readStreamsLock.Unlock()
@@ -46,13 +63,6 @@ func (s *session) getOrCreateReadStream(ssrc uint32, child streamSession, proto 
 		return proto, true
 	}
 	return r, false
-}
-
-func (s *session) initalize() {
-	s.readStreams = map[uint32]readStream{}
-	s.newStream = make(chan readStream)
-	s.started = make(chan interface{})
-	s.closed = make(chan interface{})
 }
 
 func (s *session) close() error {


### PR DESCRIPTION
- Add an abstraction to exchange keying material between the DTLS
  and SRTP package.
- Construct & start the Session at the same time to avoid races.

This makes `RTCDtlsTransport.startSRTP()` look as follows:
```go
keys, err := srtp.ExtractSessionKeysFromDTLS(t.conn, t.isClient())
if err != nil {
	return fmt.Errorf("failed to extract sctp session keys: %v", err)
}

srtpConfig := &srtp.Config{
	Keys:    keys,
	Profile: srtp.ProtectionProfileAes128CmHmacSha1_80,
}

srtpSession, err := srtp.NewSessionSRTP(t.srtpEndpoint, srtpConfig)
if err != nil {
	return fmt.Errorf("failed to start srtp: %v", err)
}

srtcpSession, err := srtp.NewSessionSRTCP(t.srtcpEndpoint, srtpConfig)
if err != nil {
	return fmt.Errorf("failed to start srtcp: %v", err)
}

t.srtpSession = srtpSession
t.srtcpSession = srtcpSession
```