### PR TITLE
 Speed up EncryptRTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Michiel De Backker](https://github.com/backkem) - *io.Writer interfaces*
 * [Tobias Fridén](https://github.com/tobiasfriden) *SRTP authentication verification*
 * [chenkaiC4](https://github.com/chenkaiC4) - *Fix GolangCI Linter*
+* [Luke Curley](https://github.com/kixelated) - *Performance*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -122,6 +122,7 @@ func (w *WriteStreamSRTP) WriteRTP(header *rtp.Header, payload []byte) (int, err
 		return 0, err
 	}
 
+	// TODO(@lcurley) This will cause one, potentially two, extra allocations.
 	return w.session.write(append(headerRaw, payload...))
 }
 

--- a/util.go
+++ b/util.go
@@ -2,6 +2,17 @@ package srtp
 
 import "bytes"
 
+// Grow the buffer size to the given number of bytes.
+func growBufferSize(buf []byte, size int) []byte {
+	if size <= cap(buf) {
+		return buf[:size]
+	}
+
+	buf2 := make([]byte, size)
+	copy(buf2, buf)
+	return buf2
+}
+
 // Check if buffers match, if not allocate a new buffer and return it
 func allocateIfMismatch(dst, src []byte) []byte {
 	if dst == nil {


### PR DESCRIPTION
**new:**
```
BenchmarkEncryptRTP-8          	  300000	      5181 ns/op	    2512 B/op	      11 allocs/op
BenchmarkEncryptRTPInPlace-8   	  300000	      4480 ns/op	    1104 B/op	      10 allocs/op
```

**old:**
```
BenchmarkEncryptRTP-8          	  200000	      6378 ns/op	    4304 B/op	      12 allocs/op
BenchmarkEncryptRTPInPlace-8   	  300000	      4448 ns/op	    1104 B/op	      10 allocs/op
```

The old code would:

1. `allocateIfMismatch` performs `bytes.Equal` to check if the dst/src
are the same. It's not needed, it could technically have false-positives,
and it could have been done faster with pointers anyway.
    ex: `&dst[0] == &src[0]`

2. `allocateIfMismatch` would always copy the payload, even if we're
just about to overwrite it with encrypted data.

3. `allocateIfMismatch` will make a byte slice of the size/cap of the
payload slice, but won't include extra room for the auth tag (10 bytes)
we're expecting to append. This means that we will always cause an extra
realloc/copy, as evidenced by the benchmark memstats.

The unit test to check if the encryption was done in place was broken.
The ciphertext was being written to the dst, but then append was used
to write the auth tag. This causes a reallocation unless the dst is
allocated with 10 extra bytes of overhead. So encrypting in place would
often not work.

I switched the API to explicitly append instead of write to [0]. The
stdlib likes to switch kind of arbitrarily between both approaches. If
the output size is not trivial, then it will always append. But if the
output size is fixed, then it can write in place. When the output size
can be calculated (like `len(plaintext)+10`), most APIs still use append.
For example, cipher.Block writes to indexes directly while cipher.AEAD
will append because it also attaches an auth tag.

Writing to indexes directly should always error if `len(dst)` is not large
enough, as a way to guarantee against reallocations. The current approach
uses append under the hood so it's better to be explicit that there may be
a reallocation.

You can still append to the same slice by using `dst[:0]`. It will set
the len to 0 but the cap will stay the same.