### PR TITLE
Optimize session auth tag generation

### DIFF
--- a/srtcp.go
+++ b/srtcp.go
@@ -62,7 +62,7 @@ func (c *Context) encryptRTCP(dst, decrypted []byte) ([]byte, error) {
 	binary.BigEndian.PutUint32(out[len(out)-4:], c.srtcpIndex)
 	out[len(out)-4] |= 0x80
 
-	authTag, err := c.generateAuthTag(out, c.srtcpSessionAuthTag)
+	authTag, err := c.generateSrtcpAuthTag(out)
 	if err != nil {
 		return nil, err
 	}

--- a/srtp_test.go
+++ b/srtp_test.go
@@ -331,3 +331,34 @@ func BenchmarkEncryptRTPInPlace(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkDecryptRTP(b *testing.B) {
+	sequenceNumber := uint16(5000)
+	encrypted := []byte{0x6d, 0xd3, 0x7e, 0xd5, 0x99, 0xb7, 0x2d, 0x28, 0xb1, 0xf3, 0xa1, 0xf0, 0xc, 0xfb, 0xfd, 0x8}
+
+	encryptedPkt := &rtp.Packet{
+		Payload: encrypted,
+		Header: rtp.Header{
+			SequenceNumber: sequenceNumber,
+		},
+	}
+
+	encryptedRaw, err := encryptedPkt.Marshal()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	context, err := buildTestContext()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := context.DecryptRTP(nil, encryptedRaw, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
I profiled my application and crypto/hmac.New was taking 5.71% of the
total CPU time. Since the session key does not change, you can call
crypto/hmac.Reset() instead of making a new object. This reuses previous
work done for the key.

```
name                 old time/op  new time/op  delta
EncryptRTP-8         2.17µs ± 4%  1.90µs ± 5%  -12.79%  (p=0.008 n=5+5)
EncryptRTPInPlace-8  2.14µs ± 4%  1.84µs ± 4%  -13.79%  (p=0.008 n=5+5)
```