### PR TITLE
Fix out-of-bounds slice access in DecryptRTCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Tobias Fridén](https://github.com/tobiasfriden) *SRTP authentication verification*
 * [chenkaiC4](https://github.com/chenkaiC4) - *Fix GolangCI Linter*
 * [Luke Curley](https://github.com/kixelated) - *Performance*
+* [Chris Hiszpanski](https://github.com/thinkski) - *Fix out-of-bounds access*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/srtcp.go
+++ b/srtcp.go
@@ -18,10 +18,9 @@ func (c *Context) decryptRTCP(dst, encrypted []byte) ([]byte, error) {
 		return out, nil
 	}
 
-	srtcpIndexBuffer := out[tailOffset : tailOffset+srtcpIndexSize]
-	srtcpIndexBuffer[0] &= 0x7f // unset Encryption bit
+	srtcpIndexBuffer := encrypted[tailOffset : tailOffset+srtcpIndexSize]
 
-	index := binary.BigEndian.Uint32(srtcpIndexBuffer)
+	index := binary.BigEndian.Uint32(srtcpIndexBuffer) &^ (1 << 31)
 	ssrc := binary.BigEndian.Uint32(encrypted[4:])
 
 	stream := cipher.NewCTR(c.srtcpBlock, c.generateCounter(uint16(index&0xffff), index>>16, ssrc, c.srtcpSessionSalt))


### PR DESCRIPTION
Slice was truncated to exclude the authentication portion, but was
then accessed beyond the truncated portion to read the index. Test
did not catch it because slice backing memory happened to be valid.

Replaced unsetting of 'encrypted' bit in memory with a bitmask on
index, as that is all it was needed for. With only the above fix,
tests would now fail. Both changes are necessary for tests to pass.

Fixes #10 