### PR TITLE
Optimize WriteRTP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/pions/srtp
 
 require (
 	github.com/pions/rtcp v1.1.0
-	github.com/pions/rtp v1.0.1
+	github.com/pions/rtp v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pions/rtcp v1.1.0 h1:WJarRpNaGE7aScgTXARaNIObMhIbftcbiPuhhqvDtl4=
 github.com/pions/rtcp v1.1.0/go.mod h1:Q5twXlqiz775Yn37X0cl4lAsfSk8EiHgeNkte59jBY4=
-github.com/pions/rtp v1.0.1 h1:NJyBplPVXSkW+nL/4m8ofF1XvgNIEhoyUnlTontmOCo=
-github.com/pions/rtp v1.0.1/go.mod h1:GDIt4UYlSz7za4vfaLqihGJJ+yLvgPshnqrF/lm3vcM=
+github.com/pions/rtp v1.1.0 h1:aioiXSi2UclJptFRqmii76GTrlgry5ucCGtdKc+5VDs=
+github.com/pions/rtp v1.1.0/go.mod h1:Bro/2l0PS5C3SQaEpLA+H34kpKIurx3K2Zln/nKjRMs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -120,15 +120,9 @@ type WriteStreamSRTP struct {
 	session *SessionSRTP
 }
 
-// WriteRTP encrypts a RTP header and its payload to the nextConn
+// WriteRTP encrypts a RTP packet and writes to the connection
 func (w *WriteStreamSRTP) WriteRTP(header *rtp.Header, payload []byte) (int, error) {
-	headerRaw, err := header.Marshal()
-	if err != nil {
-		return 0, err
-	}
-
-	// TODO(@lcurley) This will cause one, potentially two, extra allocations.
-	return w.session.write(append(headerRaw, payload...))
+	return w.session.writeRTP(header, payload)
 }
 
 // Write encrypts and writes a full RTP packets to the nextConn

--- a/stream_srtp_test.go
+++ b/stream_srtp_test.go
@@ -1,0 +1,124 @@
+package srtp
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pions/rtp"
+)
+
+type noopConn struct{ closed chan struct{} }
+
+func newNoopConn() *noopConn                           { return &noopConn{closed: make(chan struct{})} }
+func (c *noopConn) Read(b []byte) (n int, err error)   { <-c.closed; return 0, io.EOF }
+func (c *noopConn) Write(b []byte) (n int, err error)  { return len(b), nil }
+func (c *noopConn) Close() error                       { close(c.closed); return nil }
+func (c *noopConn) LocalAddr() net.Addr                { return nil }
+func (c *noopConn) RemoteAddr() net.Addr               { return nil }
+func (c *noopConn) SetDeadline(t time.Time) error      { return nil }
+func (c *noopConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *noopConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func BenchmarkWrite(b *testing.B) {
+	conn := newNoopConn()
+
+	config := &Config{
+		Keys: SessionKeys{
+			LocalMasterKey:   make([]byte, 16),
+			LocalMasterSalt:  make([]byte, 14),
+			RemoteMasterKey:  make([]byte, 16),
+			RemoteMasterSalt: make([]byte, 14),
+		},
+		Profile: ProtectionProfileAes128CmHmacSha1_80,
+	}
+
+	session, err := NewSessionSRTP(conn, config)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ws, err := session.OpenWriteStream()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	packet := &rtp.Packet{
+		Header: rtp.Header{
+			Version: 2,
+			SSRC:    322,
+		},
+		Payload: make([]byte, 100),
+	}
+
+	packetRaw, err := packet.Marshal()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		packet.Header.SequenceNumber++
+
+		_, err = ws.Write(packetRaw)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	err = session.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func BenchmarkWriteRTP(b *testing.B) {
+	conn := &noopConn{
+		closed: make(chan struct{}),
+	}
+
+	config := &Config{
+		Keys: SessionKeys{
+			LocalMasterKey:   make([]byte, 16),
+			LocalMasterSalt:  make([]byte, 14),
+			RemoteMasterKey:  make([]byte, 16),
+			RemoteMasterSalt: make([]byte, 14),
+		},
+		Profile: ProtectionProfileAes128CmHmacSha1_80,
+	}
+
+	session, err := NewSessionSRTP(conn, config)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ws, err := session.OpenWriteStream()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	header := &rtp.Header{
+		Version: 2,
+		SSRC:    322,
+	}
+
+	payload := make([]byte, 100)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		header.SequenceNumber++
+
+		_, err = ws.WriteRTP(header, payload)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	err = session.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
The old EncryptRTP API causes an extra header Unmarshal and payload
Marshal. By passing the `*rtp.Packet` through the stack, we're able to
avoid both of these.

There was also an extra reallocation caused by using append.

```
name                 old time/op  new time/op  delta
EncryptRTP-8         1.94µs ± 3%  1.94µs ± 3%    ~
EncryptRTPInPlace-8  1.89µs ± 3%  1.89µs ± 4%    ~
DecryptRTP-8         1.80µs ± 3%  1.83µs ± 7%    ~
Write-8              1.95µs ± 8%  1.93µs ± 1%   ~
WriteRTP-8           2.11µs ± 6%  2.01µs ± 8%  -4.71%
```