### PR TITLE
Optimize getOrCreateReadStream

### DIFF
--- a/session.go
+++ b/session.go
@@ -45,7 +45,7 @@ type SessionKeys struct {
 	RemoteMasterSalt []byte
 }
 
-func (s *session) getOrCreateReadStream(ssrc uint32, child streamSession, proto readStream) (readStream, bool) {
+func (s *session) getOrCreateReadStream(ssrc uint32, child streamSession, proto func() readStream) (readStream, bool) {
 	s.readStreamsLock.Lock()
 	defer s.readStreamsLock.Unlock()
 
@@ -54,15 +54,19 @@ func (s *session) getOrCreateReadStream(ssrc uint32, child streamSession, proto 
 	}
 
 	r, ok := s.readStreams[ssrc]
-	if !ok {
-		if err := proto.init(child, ssrc); err != nil {
-			return nil, false
-		}
-
-		s.readStreams[ssrc] = proto
-		return proto, true
+	if ok {
+		return r, false
 	}
-	return r, false
+
+	// Create the readStream.
+	r = proto()
+
+	if err := r.init(child, ssrc); err != nil {
+		return nil, false
+	}
+
+	s.readStreams[ssrc] = r
+	return r, true
 }
 
 func (s *session) removeReadStream(ssrc uint32) {

--- a/session_srtcp.go
+++ b/session_srtcp.go
@@ -51,7 +51,7 @@ func (s *SessionSRTCP) OpenWriteStream() (*WriteStreamSRTCP, error) {
 // OpenReadStream opens a read stream for the given SSRC, it can be used
 // if you want a certain SSRC, but don't want to wait for AcceptStream
 func (s *SessionSRTCP) OpenReadStream(SSRC uint32) (*ReadStreamSRTCP, error) {
-	r, _ := s.session.getOrCreateReadStream(SSRC, s, &ReadStreamSRTCP{})
+	r, _ := s.session.getOrCreateReadStream(SSRC, s, newReadStreamSRTCP)
 
 	if readStream, ok := r.(*ReadStreamSRTCP); ok {
 		return readStream, nil
@@ -119,7 +119,7 @@ func (s *SessionSRTCP) decrypt(buf []byte) error {
 		}
 
 		for _, ssrc := range report.DestinationSSRC() {
-			r, isNew := s.session.getOrCreateReadStream(ssrc, s, &ReadStreamSRTCP{})
+			r, isNew := s.session.getOrCreateReadStream(ssrc, s, newReadStreamSRTCP)
 			if r == nil {
 				return nil // Session has been closed
 			} else if isNew {

--- a/session_srtp.go
+++ b/session_srtp.go
@@ -55,7 +55,7 @@ func (s *SessionSRTP) OpenWriteStream() (*WriteStreamSRTP, error) {
 // OpenReadStream opens a read stream for the given SSRC, it can be used
 // if you want a certain SSRC, but don't want to wait for AcceptStream
 func (s *SessionSRTP) OpenReadStream(SSRC uint32) (*ReadStreamSRTP, error) {
-	r, _ := s.session.getOrCreateReadStream(SSRC, s, &ReadStreamSRTP{})
+	r, _ := s.session.getOrCreateReadStream(SSRC, s, newReadStreamSRTP)
 
 	if readStream, ok := r.(*ReadStreamSRTP); ok {
 		return readStream, nil
@@ -104,7 +104,7 @@ func (s *SessionSRTP) decrypt(buf []byte) error {
 		return err
 	}
 
-	r, isNew := s.session.getOrCreateReadStream(h.SSRC, s, &ReadStreamSRTP{})
+	r, isNew := s.session.getOrCreateReadStream(h.SSRC, s, newReadStreamSRTP)
 	if r == nil {
 		return nil // Session has been closed
 	} else if isNew {

--- a/stream_srtcp.go
+++ b/stream_srtcp.go
@@ -25,6 +25,11 @@ type ReadStreamSRTCP struct {
 	readRetCh chan readResultSRTCP
 }
 
+// Used by getOrCreateReadStream
+func newReadStreamSRTCP() readStream {
+	return &ReadStreamSRTCP{}
+}
+
 // ReadRTCP reads and decrypts full RTCP packet and its header from the nextConn
 func (r *ReadStreamSRTCP) ReadRTCP(payload []byte) (int, *rtcp.Header, error) {
 	select {

--- a/stream_srtp.go
+++ b/stream_srtp.go
@@ -25,6 +25,11 @@ type ReadStreamSRTP struct {
 	readRetCh chan readResultSRTP
 }
 
+// Used by getOrCreateReadStream
+func newReadStreamSRTP() readStream {
+	return &ReadStreamSRTP{}
+}
+
 // ReadRTP reads and decrypts full RTP packet and its header from the nextConn
 func (r *ReadStreamSRTP) ReadRTP(payload []byte) (int, *rtp.Header, error) {
 	select {


### PR DESCRIPTION
The allocation of a readStream every time was causing a ton of
allocations for no reason. Passing in a function avoids the
allocation.