### PR TITLE
Avoid printing EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [chenkaiC4](https://github.com/chenkaiC4) - *Fix GolangCI Linter*
 * [Luke Curley](https://github.com/kixelated) - *Performance*
 * [Chris Hiszpanski](https://github.com/thinkski) - *Fix out-of-bounds access*
+* [Yutaka Takeda](https://github.com/enobufs) - *Fix log messages*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/session.go
+++ b/session.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"sync"
 )
@@ -118,7 +119,9 @@ func (s *session) start(localMasterKey, localMasterSalt, remoteMasterKey, remote
 			var i int
 			i, err = s.nextConn.Read(b)
 			if err != nil {
-				fmt.Println(err)
+				if err != io.EOF {
+					fmt.Printf("srtp: %s\n", err.Error())
+				}
 				return
 			}
 


### PR DESCRIPTION
"EOF" has been showing up on the console almost always and finally found it was coming from srtp.  Let's not print EOF as it is an expected one. (once logging facility becomes available, we should remove fmt.Print*() completely.

Related to pions/webrtc#361
